### PR TITLE
refactor(all): renaming atom references to Inkdrop one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
-# apm - Atom Package Manager
+# ipm - Inkdrop Package Manager
 
-![Build Status](https://github.com/atom-ide-community/apm/workflows/CI/badge.svg)
-[![Dependency Status](https://david-dm.org/atom/apm.svg)](https://david-dm.org/atom/apm)
+Discover and install Inkdrop packages powered by [inkdrop.app](https://my.inkdrop.app/plugins)
 
-Discover and install Atom packages powered by [atom.io](https://atom.io)
-
-You can configure apm by using the `apm config` command line option (recommended) or by manually editing the `~/.atom/.apmrc` file as per the [npm config](https://docs.npmjs.com/misc/config).
+You can configure ipm by using the `ipm config` command line option (recommended) or by manually editing the `~/.config/inkdrop/.ipmrc` file as per the [npm config](https://docs.npmjs.com/misc/config).
 
 ## Relation to npm
 
-apm bundles [npm](https://github.com/npm/npm) with it and spawns `npm` processes to install Atom packages. The major difference is that `apm` sets multiple command line arguments to `npm` to ensure that native modules are built against Chromium's v8 headers instead of node's v8 headers.
+ipm bundles [npm](https://github.com/npm/npm) with it and spawns `npm` processes to install Inkdrop packages. The major difference is that `ipm` sets multiple command line arguments to `npm` to ensure that native modules are built against Chromium's v8 headers instead of node's v8 headers.
 
-The other major difference is that Atom packages are installed to `~/.atom/packages` instead of a local `node_modules` folder and Atom packages are published to and installed from GitHub repositories instead of [npmjs.com](https://www.npmjs.com/)
+The other major difference is that Inkdrop packages are installed to `~/.config/inkdrop/packages` instead of a local `node_modules` folder and Inkdrop packages are published to and installed from GitHub repositories instead of [npmjs.com](https://www.npmjs.com/)
 
-Therefore you can think of `apm` as a simple `npm` wrapper that builds on top of the many strengths of `npm` but is customized and optimized to be used for Atom packages.
+Therefore you can think of `ipm` as a simple `npm` wrapper that builds on top of the many strengths of `npm` but is customized and optimized to be used for Inkdrop packages.
 
 ## Installing
 
-`apm` is bundled and installed automatically with Atom. You can run the _Atom > Install Shell Commands_ menu option to install it again if you aren't able to run it from a terminal (macOS only).
+`ipm` is bundled and installed automatically with Inkdrop. You can run the _Inkdrop > Install Shell Commands_ menu option to install it again if you aren't able to run it from a terminal (macOS only).
 
 ## Building
 
@@ -29,16 +26,16 @@ Therefore you can think of `apm` as a simple `npm` wrapper that builds on top of
 
 ### Why `bin/npm` / `bin\npm.cmd`?
 
-`apm` includes `npm`, and spawns it for various processes. It also comes with a bundled version of Node, and this script ensures that npm uses the right version of Node for things like running the tests. If you're using the same version of Node as is listed in `BUNDLED_NODE_VERSION`, you can skip using this script.
+`ipm` includes `npm`, and spawns it for various processes. It also comes with a bundled version of Node, and this script ensures that npm uses the right version of Node for things like running the tests. If you're using the same version of Node as is listed in `BUNDLED_NODE_VERSION`, you can skip using this script.
 
 ## Using
 
-Run `apm help` to see all the supported commands and `apm help <command>` to
+Run `ipm help` to see all the supported commands and `ipm help <command>` to
 learn more about a specific command.
 
-The common commands are `apm install <package_name>` to install a new package,
-`apm featured` to see all the featured packages, and `apm publish` to publish
-a package to [atom.io](https://atom.io).
+The common commands are `ipm install <package_name>` to install a new package,
+`ipm featured` to see all the featured packages, and `ipm publish` to publish
+a package to [inkdrop.app](https://my.inkdrop.app/plugins).
 
 ## Two-factor authentication?
 
@@ -50,19 +47,19 @@ If you are behind a firewall and seeing SSL errors when installing packages
 you can disable strict SSL by running:
 
 ```
-apm config set strict-ssl false
+ipm config set strict-ssl false
 ```
 
 ## Using a proxy?
 
-If you are using a HTTP(S) proxy you can configure `apm` to use it by running:
+If you are using a HTTP(S) proxy you can configure `ipm` to use it by running:
 
 ```
-apm config set https-proxy https://9.0.2.1:0
+ipm config set https-proxy https://9.0.2.1:0
 ```
 
-You can run `apm config get https-proxy` to verify it has been set correctly.
+You can run `ipm config get https-proxy` to verify it has been set correctly.
 
 ## Viewing configuration
 
-You can also run `apm config list` to see all the custom config settings.
+You can also run `ipm config list` to see all the custom config settings.

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -132,7 +132,7 @@ module.exports =
         ; This file is auto-generated and should not be edited since any
         ; modifications will be lost the next time any apm command is run.
         ;
-        ; You should instead edit your .apmrc config located in ~/.atom/.apmrc
+        ; You should instead edit your .ipmrc config located in ~/.config/inkdrop/.ipmrc
         cache = #{@getCacheDirectory()}
         ; Hide progress-bar to prevent npm from altering apm console output.
         progress = false

--- a/src/develop.coffee
+++ b/src/develop.coffee
@@ -29,7 +29,7 @@ class Develop extends Command
 
       Clone the given package's Git repository to the directory specified,
       install its dependencies, and link it for development to
-      ~/.atom/dev/packages/<package_name>.
+      ~/.config/inkdrop/dev/packages/<package_name>.
 
       If no directory is specified then the repository is cloned to
       ~/github/<package_name>. The default folder to clone packages into can

--- a/src/link.coffee
+++ b/src/link.coffee
@@ -17,7 +17,7 @@ class Link extends Command
 
       Usage: ipm link [<package_path>] [--name <package_name>]
 
-      Create a symlink for the package in ~/.atom/packages. The package in the
+      Create a symlink for the package in ~/.config/inkdrop/packages. The package in the
       current working directory is linked if no path is given.
 
       Run `ipm links` to view all the currently linked packages.

--- a/src/links.coffee
+++ b/src/links.coffee
@@ -22,8 +22,8 @@ class Links extends Command
 
       Usage: ipm links
 
-      List all of the symlinked atom packages in ~/.atom/packages and
-      ~/.atom/dev/packages.
+      List all of the symlinked atom packages in ~/.config/inkdrop/packages and
+      ~/.config/inkdrop/dev/packages.
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')
 

--- a/src/rebuild-module-cache.coffee
+++ b/src/rebuild-module-cache.coffee
@@ -20,7 +20,7 @@ class RebuildModuleCache extends Command
       Usage: ipm rebuild-module-cache
 
       Rebuild the module cache for all the packages installed to
-      ~/.atom/packages
+      ~/.config/inkdrop/packages
 
       You can see the state of the module cache for a package by looking
       at the _atomModuleCache property in the package's package.json file.

--- a/src/star.coffee
+++ b/src/star.coffee
@@ -27,7 +27,7 @@ class Star extends Command
       Run `ipm stars` to see all your starred packages.
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')
-    options.boolean('installed').describe('installed', 'Star all packages in ~/.atom/packages')
+    options.boolean('installed').describe('installed', 'Star all packages in ~/.config/inkdrop/packages')
 
   starPackage: (packageName, {ignoreUnpublishedPackages, token}={}, callback) ->
     process.stdout.write '\u2B50  ' if process.platform is 'darwin'

--- a/src/uninstall.coffee
+++ b/src/uninstall.coffee
@@ -20,11 +20,11 @@ class Uninstall extends Command
 
       Usage: ipm uninstall <package_name>...
 
-      Delete the installed package(s) from the ~/.atom/packages directory.
+      Delete the installed package(s) from the ~/.config/inkdrop/packages directory.
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')
-    options.alias('d', 'dev').boolean('dev').describe('dev', 'Uninstall from ~/.atom/dev/packages')
-    options.boolean('hard').describe('hard', 'Uninstall from ~/.atom/packages and ~/.atom/dev/packages')
+    options.alias('d', 'dev').boolean('dev').describe('dev', 'Uninstall from ~/.config/inkdrop/dev/packages')
+    options.boolean('hard').describe('hard', 'Uninstall from ~/.config/inkdrop/packages and ~/.config/inkdrop/dev/packages')
 
   getPackageVersion: (packageDirectory) ->
     try

--- a/src/unlink.coffee
+++ b/src/unlink.coffee
@@ -22,15 +22,15 @@ class Unlink extends Command
 
       Usage: ipm unlink [<package_path>]
 
-      Delete the symlink in ~/.atom/packages for the package. The package in the
+      Delete the symlink in ~/.config/inkdrop/packages for the package. The package in the
       current working directory is unlinked if no path is given.
 
       Run `ipm links` to view all the currently linked packages.
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')
-    options.alias('d', 'dev').boolean('dev').describe('dev', 'Unlink package from ~/.atom/dev/packages')
-    options.boolean('hard').describe('hard', 'Unlink package from ~/.atom/packages and ~/.atom/dev/packages')
-    options.alias('a', 'all').boolean('all').describe('all', 'Unlink all packages in ~/.atom/packages and ~/.atom/dev/packages')
+    options.alias('d', 'dev').boolean('dev').describe('dev', 'Unlink package from ~/.config/inkdrop/dev/packages')
+    options.boolean('hard').describe('hard', 'Unlink package from ~/.config/inkdrop/packages and ~/.config/inkdrop/dev/packages')
+    options.alias('a', 'all').boolean('all').describe('all', 'Unlink all packages in ~/.config/inkdrop/packages and ~/.config/inkdrop/dev/packages')
 
   getDevPackagePath: (packageName) -> path.join(@devPackagesPath, packageName)
 

--- a/src/upgrade.coffee
+++ b/src/upgrade.coffee
@@ -33,7 +33,7 @@ class Upgrade extends Command
              ipm upgrade --list
              ipm upgrade [<package_name>...]
 
-      Upgrade out of date packages installed to ~/.atom/packages
+      Upgrade out of date packages installed to ~/.config/inkdrop/packages
 
       This command lists the out of date packages and then prompts to install
       available updates.


### PR DESCRIPTION
### Renamed most Atom References to Inkdrop one

There is not much code changes except the `~/.atom/` path is changed to `~/.config/inkdrop/` and the plugins registry from `https://atom.io` to `https://my.inkdrop.app/plugins`